### PR TITLE
Add option to slow-fetch screenshots in the background

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,5 +65,5 @@ curl 'http://localhost:8080/api/spectura/v0/screenshot?s=555426697a26bb43af02808
 * `SIGNING_SECRET`, required if `USE_SIGNATURES`
 * `SIGNING_KEY`, required if `USE_SIGNATURES`
 * `SIGNING_UNIQUE_NAME`, optional, default: `jix_spectura`
-* `CACHE_TTL`, optional, default: `12h`
+* `CACHE_TTL`, optional, default: `48h`
 * `MAX_IMAGE_SIZE_MIB`, optional, default: `20`

--- a/cache.go
+++ b/cache.go
@@ -8,15 +8,14 @@ import (
 	"time"
 )
 
-// A CacheEntry wraps a PNG-encoded image to stored in a Cache. The screenshot
-// URL is used as the cache key.
+// A CacheEntry wraps a PNG-encoded image to stored in a Cache. The screenshot // URL is used as the cache key.
 type CacheEntry struct {
 	Image       []byte
 	Signature   string
 	URL         *url.URL
-	first       time.Time
-	lastUpdated time.Time
-	lastFetched time.Time
+	First       time.Time
+	LastUpdated time.Time
+	LastFetched time.Time
 }
 
 // IsEmpty reports whether e is a zero value CacheEntry.
@@ -100,28 +99,28 @@ func (c *Cache) serve() {
 			}
 			c.readReply <- replyEntry
 			if exists {
-				entry.lastFetched = time.Now()
+				entry.LastFetched = time.Now()
 				c.entries[url] = entry
 			}
 
 		case entry := <-c.writeQuery:
 			now := time.Now()
 			if oldEntry, exists := c.entries[entry.URL.String()]; exists {
-				entry.lastFetched = oldEntry.lastFetched
+				entry.LastFetched = oldEntry.LastFetched
 			} else {
-				entry.first = now
-				entry.lastFetched = now
+				entry.First = now
+				entry.LastFetched = now
 			}
-			entry.lastUpdated = now
+			entry.LastUpdated = now
 			c.entries[entry.URL.String()] = entry
 
-		// TODO: Auto-refresh cached images if time.Since(entry.lastUpdated)
+		// TODO: Auto-refresh cached images if time.Since(entry.LastUpdated)
 		// 	     is larger than e.g. 6 hours.
 
 		case <-purge.C:
 			size := 0
 			for url, entry := range c.entries {
-				elapsed := time.Since(entry.lastFetched)
+				elapsed := time.Since(entry.LastFetched)
 				if elapsed > c.ttl {
 					delete(c.entries, url)
 					fmt.Fprintf(os.Stderr, "Clearing cache entry %s\n", url)

--- a/cache.go
+++ b/cache.go
@@ -8,7 +8,8 @@ import (
 	"time"
 )
 
-// A CacheEntry wraps a PNG-encoded image to stored in a Cache. The screenshot // URL is used as the cache key.
+// A CacheEntry wraps a PNG-encoded image to stored in a Cache. The screenshot
+// URL is used as the cache key.
 type CacheEntry struct {
 	Expire      time.Time
 	Image       []byte

--- a/cache.go
+++ b/cache.go
@@ -36,7 +36,7 @@ func (e *CacheEntry) IsFailedImage() bool {
 //
 // LastFetched is updated if it contains a newer timestamp.
 //
-// URL is never updated.
+// Expire and URL are never updated.
 func (e *CacheEntry) merge(o CacheEntry) {
 	e.Image = o.Image
 	e.LastUpdated = time.Now()

--- a/cache.go
+++ b/cache.go
@@ -147,7 +147,7 @@ func (c *Cache) serve() {
 		case <-purge.C:
 			size := 0
 			for url, entry := range c.entries {
-				elapsed := time.Since(entry.LastFetched)
+				elapsed := time.Since(entry.LastUpdated)
 				if elapsed > c.ttl {
 					delete(c.entries, url)
 					fmt.Fprintf(os.Stderr, "Clearing cache entry %s\n", url)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       "SIGNING_SECRET": "secret"
       "SIGNING_KEY": "key"
       "SIGNING_UNIQUE_NAME": "jix_spectura"
+      "BG_RATE_LIMIT_TIME": "10s"
     volumes:
       - "./templates:/templates"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       "SIGNING_KEY": "key"
       "SIGNING_UNIQUE_NAME": "jix_spectura"
     volumes:
-      - "./templates:/app/templates"
+      - "./templates:/templates"
     depends_on:
       - decap
     build:

--- a/info.go
+++ b/info.go
@@ -55,7 +55,7 @@ func (e *CacheEntry) FmtSize() string {
 func (e *CacheEntry) SpecturaURL() string {
 	specturaURL, _ := url.Parse(screenshotPath)
 	query := specturaURL.Query()
-	query.Set("url", e.URL)
+	query.Set("url", e.URL.String())
 	if useSignatures {
 		query.Set("s", e.Signature)
 	}

--- a/main.go
+++ b/main.go
@@ -157,6 +157,7 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 			if elapsed < 3*time.Hour {
 				msg := fmt.Sprintf("%s since last background request", elapsed)
 				http.Error(w, msg, http.StatusTooManyRequests)
+				return
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -153,15 +153,17 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 			entry.URL = targetURL
 			entry.Signature = signature
 		} else {
-			elapsed := time.Since(entry.lastUpdated)
+			elapsed := time.Since(entry.LastUpdated)
 			if elapsed < 3*time.Hour {
 				msg := fmt.Sprintf("%s since last background request", elapsed)
 				http.Error(w, msg, http.StatusTooManyRequests)
 			}
 		}
 
-		// TODO: Update timestamp in cache, so repeated queries are rejected
-		// 		 while the initial query is still being processed.
+		// Update timestamp in cache, so repeated queries are rejected
+		// while the initial query is still being processed.
+		entry.LastUpdated = time.Now()
+		cache.Write(entry)
 
 		cache.RefreshEntry(entry)
 		return

--- a/main.go
+++ b/main.go
@@ -175,8 +175,9 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 
 	if query.Get("bg") != "" {
 		if entry.IsEmpty() {
-			entry.URL = targetURL
+			entry.Expire = time.Unix(expire, 0)
 			entry.Signature = signature
+			entry.URL = targetURL
 		} else {
 			elapsed := time.Since(entry.LastUpdated)
 			if elapsed < bgRateLimitTime {

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ var cache Cache
 func main() {
 	rand.Seed(time.Now().UnixNano())
 
-	cacheTTLString, _ := getenv("CACHE_TTL", "12h")
+	cacheTTLString, _ := getenv("CACHE_TTL", "48h")
 	cacheTTL, err := time.ParseDuration(cacheTTLString)
 	if err != nil {
 		log.Fatalf(`CACHE_TTL must be a valid duration such as "12h": %s\n`, err)

--- a/main.go
+++ b/main.go
@@ -198,7 +198,7 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 	if entry.IsEmpty() {
 		entry.Expire = time.Unix(expire, 0)
 		entry.Signature = signature
-		entry.URL = targetURL.String()
+		entry.URL = targetURL
 		err = entry.fetchAndCropImage(false, false)
 		switch {
 		case err == nil:

--- a/templates/info.tmpl.html
+++ b/templates/info.tmpl.html
@@ -44,6 +44,24 @@
                       <a name="url" href="{{.URL}}">{{.URL}}</a>
                     </div>
                   </div>
+                  <div class="row">
+                    <div class="col"> <b>First</b> </div>
+                  </div>
+                  <div class="row">
+                    <div class="col">{{.First | formatDate}}</div>
+                  </div>
+                  <div class="row">
+                    <div class="col"> <b>LastUpdated</b> </div>
+                  </div>
+                  <div class="row">
+                    <div class="col">{{.LastUpdated | formatDate }}</div>
+                  </div>
+                  <div class="row">
+                    <div class="col"> <b>LastFetched</b> </div>
+                  </div>
+                  <div class="row">
+                    <div class="col">{{.LastFetched | formatDate}}</div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/templates/info.tmpl.html
+++ b/templates/info.tmpl.html
@@ -20,54 +20,56 @@
       </div>
       {{range .CacheEntries}}
         <div class="card mb-3">
+          <div class="card-header">
+            <b>URL:</b>
+            <a name="url" href="{{.URL}}"> {{.URL}} </a>
+          </div>
           <div class="card-body">
             <div class="row">
-              <div class="col-6">
-                <img class="img-thumbnail" src="{{ .SpecturaURL }}" />
-              </div>
               <div class="col">
                 <div class="row">
+                  <div class="col-3">
+                    <b>Size:</b>
+                  </div>
                   <div class="col">
-                    <b>Size</b>
+                    {{.FmtSize}}
                   </div>
                 </div>
                 <div class="row">
-                  <div class="col">{{.FmtSize}}</div>
-                </div>
-                <div class="row">
+                  <div class="col-3">
+                    <b>First:</b>
+                  </div>
                   <div class="col">
-                    <b>URL</b>
+                    {{.First | formatDate}}
                   </div>
                 </div>
                 <div class="row">
+                  <div class="col-3">
+                    <b>LastUpdated:</b>
+                  </div>
                   <div class="col">
-                    <a name="url" href="{{.URL}}"> {{.URL}} </a>
-                  </div>
-                  <div class="row">
-                    <div class="col"> <b>First</b> </div>
-                  </div>
-                  <div class="row">
-                    <div class="col">{{.First | formatDate}}</div>
-                  </div>
-                  <div class="row">
-                    <div class="col"> <b>LastUpdated</b> </div>
-                  </div>
-                  <div class="row">
-                    <div class="col">{{.LastUpdated | formatDate }}</div>
-                  </div>
-                  <div class="row">
-                    <div class="col"> <b>LastFetched</b> </div>
-                  </div>
-                  <div class="row">
-                    <div class="col">{{.LastFetched | formatDate}}</div>
+                    {{.LastUpdated | formatDate }}
                   </div>
                 </div>
                 <div class="row">
-                  <div class="col"> <b>Expire</b> </div>
+                  <div class="col-3">
+                    <b>LastFetched:</b>
+                  </div>
+                  <div class="col">
+                    {{.LastFetched | formatDate}}
+                  </div>
                 </div>
                 <div class="row">
-                  <div class="col">{{.Expire | formatDate}}</div>
+                  <div class="col-3">
+                    <b>Expire:</b>
+                  </div>
+                  <div class="col">
+                    {{.Expire | formatDate}}
+                  </div>
                 </div>
+              </div>
+              <div class="col-6">
+                <img class="img-thumbnail" src="{{ .SpecturaURL }}" />
               </div>
             </div>
           </div>


### PR DESCRIPTION
When using the query parameter `bg` with the screenshot endpoint,
Spectura now returns an empty response immediately and queues a
background job to refresh the requested screenshot at a slower pace
(i.e. larger Decap sleeping intervals).

This is useful for e.g. prefilling the cache right after the target
URL's content has been published, because the cache will be warm
when actual requests start coming in, and the cached screenshot
might even be of higher quality than one requested synchronously.

Background tasks wait until a scheduler allows them to run. The
current implementation schedules jobs at 5-second intervals, to
limit the amount of work Decap has to handle concurrently.

Co-authored-by: Asbjørn Kofoed-Nielsen <askn@jobindex.dk>