### PR TITLE
Add required `expire` query parameter.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -49,13 +49,13 @@ To test Spectura with `curl`
 
 [source,shell]
 ----
-curl 'http://localhost:8080/api/spectura/v0/screenshot?s=555426697a26bb43af02808665f0b9ae3726f5eb&url=https://pyjam.as'
+curl 'http://localhost:8080/api/spectura/v0/screenshot?url=https://pyjam.as&expire=1661810399&'
 ----
 
 If you use kitty terminal you can print the image directly in your terminal
 [source,shell]
 ----
-curl 'http://localhost:8080/api/spectura/v0/screenshot?s=555426697a26bb43af02808665f0b9ae3726f5eb&url=https://pyjam.as' | kitty +kitten icat
+curl 'http://localhost:8080/api/spectura/v0/screenshot?&url=https://pyjam.as&expire=1661810399&' | kitty +kitten icat
 ----
 
 == Configuration

--- a/cache.go
+++ b/cache.go
@@ -14,6 +14,7 @@ type CacheEntry struct {
 	Signature string
 	URL       string
 	last      time.Time
+	Expire    time.Time
 }
 
 // IsEmpty reports whether e is a zero value CacheEntry.

--- a/templates/info.tmpl.html
+++ b/templates/info.tmpl.html
@@ -44,6 +44,13 @@
                       <a name="url" href="{{.URL}}">{{.URL}}</a>
                     </div>
                   </div>
+                  <div class="row">
+                    <div class="col"> <b>Expire</b> </div>
+                  </div>
+                  <div class="row">
+                    <div class="col">{{.Expire | formatDate}}</div>
+                  </div>
+                  <div class="row">
                 </div>
               </div>
             </div>


### PR DESCRIPTION
We need to consider deployment. This change invalidates all exisiting spectura urls, because the signing method is slightly changed.

Also we need to decide what happens when the expire date is changed on an exisiting cache entry. Current behaviour is that the oldest expire date is kept.