### PR TITLE
Add required `expire` query parameter.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -49,13 +49,13 @@ To test Spectura with `curl`
 
 [source,shell]
 ----
-curl 'http://localhost:8080/api/spectura/v0/screenshot?s=555426697a26bb43af02808665f0b9ae3726f5eb&url=https://pyjam.as'
+curl 'http://localhost:8080/api/spectura/v0/screenshot?url=https://pyjam.as&expire=1661810399&'
 ----
 
 If you use kitty terminal you can print the image directly in your terminal
 [source,shell]
 ----
-curl 'http://localhost:8080/api/spectura/v0/screenshot?s=555426697a26bb43af02808665f0b9ae3726f5eb&url=https://pyjam.as' | kitty +kitten icat
+curl 'http://localhost:8080/api/spectura/v0/screenshot?&url=https://pyjam.as&expire=1661810399&' | kitty +kitten icat
 ----
 
 == Configuration

--- a/cache.go
+++ b/cache.go
@@ -14,6 +14,7 @@ type CacheEntry struct {
 	Signature string
 	URL       string
 	last      time.Time
+	Expire    time.Time
 }
 
 // IsEmpty reports whether e is a zero value CacheEntry.

--- a/main.go
+++ b/main.go
@@ -172,11 +172,9 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 
 	entry := cache.Read(targetURL.String())
 	if entry.IsEmpty() {
+		entry.Expire = time.Unix(expire, 0)
 		entry.Signature = signature
 		entry.URL = targetURL.String()
-		if expire != 0 {
-			entry.Expire = time.Unix(expire, 0)
-		}
 
 		var m image.Image
 		err = imageFromDecap(&m, targetURL, true)

--- a/main.go
+++ b/main.go
@@ -124,14 +124,14 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	expireRaw := query.Get("expire")
-	if expireRaw == "" {
-		http.Error(w, `Query param "expire" must be present`, http.StatusBadRequest)
-		return
-	}
-	expire, err := strconv.ParseInt(expireRaw, 10, 64)
-	if err != nil {
-		http.Error(w, `Query param "expire" must be a number`, http.StatusBadRequest)
-		return
+	var expire int64
+	if expireRaw != "" {
+		var err error
+		expire, err = strconv.ParseInt(expireRaw, 10, 64)
+		if err != nil {
+			http.Error(w, `Query param "expire" must be a number`, http.StatusBadRequest)
+			return
+		}
 	}
 
 	targetURL, err := url.Parse(rawURL)
@@ -143,6 +143,12 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 	if useSignatures && !checkSignature(targetURL.String(), signature, expireRaw) {
 		http.Error(w, "Signature check failed", http.StatusBadRequest)
 		return
+	}
+
+	if expire != 0 && time.Unix(expire, 0).After(time.Now()) {
+		// Return the fallback image
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(entry.Image)
 	}
 
 	if query.Get("nocrop") != "" && !useSignatures {
@@ -167,7 +173,9 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 	if entry.IsEmpty() {
 		entry.Signature = signature
 		entry.URL = targetURL.String()
-		entry.Expire = time.Unix(expire, 0)
+		if expire != 0 {
+			entry.Expire = time.Unix(expire, 0)
+		}
 
 		var m image.Image
 		err = imageFromDecap(&m, targetURL, true)

--- a/main.go
+++ b/main.go
@@ -125,6 +125,7 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 
 	expireRaw := query.Get("expire")
 	var expire int64
+	// Conditions where expire is left as 0, are handled after signature check.
 	if expireRaw != "" {
 		var err error
 		expire, err = strconv.ParseInt(expireRaw, 10, 64)
@@ -145,10 +146,10 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if expire != 0 && time.Unix(expire, 0).After(time.Now()) {
-		// Return the fallback image
-		w.Header().Set("Content-Type", "image/png")
-		w.Write(entry.Image)
+	if expire == 0 || time.Now().After(time.Unix(expire, 0)) {
+		// Redirect to fallback image
+		http.Redirect(w, req, fallbackImageURL, http.StatusFound)
+		return
 	}
 
 	if query.Get("nocrop") != "" && !useSignatures {

--- a/templates/info.tmpl.html
+++ b/templates/info.tmpl.html
@@ -44,6 +44,12 @@
                     <a name="url" href="{{.URL}}"> {{.URL}} </a>
                   </div>
                 </div>
+                <div class="row">
+                  <div class="col"> <b>Expire</b> </div>
+                </div>
+                <div class="row">
+                  <div class="col">{{.Expire | formatDate}}</div>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
We need to consider deployment. This change invalidates all exisiting spectura urls, because the signing method is slightly changed.

Also we need to decide what happens when the expire date is changed on an exisiting cache entry. Current behaviour is that the oldest expire date is kept.
