### PR TITLE
Fix update of metadata and add provenance field

### DIFF
--- a/info.go
+++ b/info.go
@@ -51,7 +51,7 @@ func infoHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	entries := cache.ReadAll()
 	sort.SliceStable(entries, func(i, j int) bool {
-		return entries[i].First.After(entries[j].First)
+		return entries[i].EntryCreated.After(entries[j].EntryCreated)
 	})
 	size := 0
 	for _, entry := range entries {

--- a/templates/info.tmpl.html
+++ b/templates/info.tmpl.html
@@ -37,18 +37,18 @@
                 </div>
                 <div class="row">
                   <div class="col-3">
-                    <b>First:</b>
+                    <b>EntryCreated:</b>
                   </div>
                   <div class="col">
-                    {{.First | formatDate}}
+                    {{.EntryCreated | formatDate}}
                   </div>
                 </div>
                 <div class="row">
                   <div class="col-3">
-                    <b>LastUpdated:</b>
+                    <b>ImageCreated:</b>
                   </div>
                   <div class="col">
-                    {{.LastUpdated | formatDate }}
+                    {{.ImageCreated | formatDate }}
                   </div>
                 </div>
                 <div class="row">
@@ -65,6 +65,14 @@
                   </div>
                   <div class="col">
                     {{.Expire | formatDate}}
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-3">
+                    <b>Provenance:</b>
+                  </div>
+                  <div class="col">
+                    {{.Provenance}}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
When perusing the info page, we would like to now _why_ a given entry was put in the cache, i.e. which client made the first real request; for this purpose we are not interested in `bg`/`nocrop` requests, image requests by the info endpoint, or followup visits.

For similar reasons, we do not want the request types listed above to pollute the various cache entry statistics. So besides adding a Provenance field, this commit tries to amend the lack of differentiation between client types by changing the following:

Renaming:
* First is now called EntryCreated
* LastUpdated is now called ImageCreated

Image and ImageCreated:
* ImageCreated isn't initialized until an actual image was created
* Updating ImageCreated is now solely the cache's responsibility
* merge only overwrites Image with non-nil images
* merge only updates ImageCreated if the image was overwritten

Request handlers:
* Request handlers now use WriteMetadata for non-image writes
* Updating LastFetched is now entirely up to the request handler
* LastFetched is not affected by `bg`, `nocrop`, or info endpoint