### PR TITLE
Auto-refresh images in the background

### DIFF
--- a/main.go
+++ b/main.go
@@ -158,8 +158,6 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if query.Get("nocrop") != "" && !useSignatures {
-		fmt.Fprintln(os.Stderr, "nocrop")
-
 		entry := CacheEntry{URL: targetURL}
 		fmt.Fprintf(os.Stderr, "Cache-miss (nocrop): %s\n", entry.URL)
 		err = entry.fetchAndCropImage(false, true)

--- a/main.go
+++ b/main.go
@@ -161,6 +161,7 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintln(os.Stderr, "nocrop")
 
 		entry := CacheEntry{URL: targetURL}
+		fmt.Fprintf(os.Stderr, "Cache-miss (nocrop): %s\n", entry.URL)
 		err = entry.fetchAndCropImage(false, true)
 		if err != nil {
 			msg := fmt.Sprintf("nocrop fail: %s", err)
@@ -204,6 +205,7 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 			Signature:   signature,
 			URL:         targetURL,
 		}
+		fmt.Fprintf(os.Stderr, "Cache miss: %s\n", entry.URL)
 		err = entry.fetchAndCropImage(false, false)
 		switch {
 		case err == nil:
@@ -217,6 +219,7 @@ func screenshotHandler(w http.ResponseWriter, req *http.Request) {
 		}
 		cache.RefreshEntry(entry)
 	} else if !strings.Contains(req.Referer(), infoPath) {
+		fmt.Fprintf(os.Stderr, "Cache hit: %s\n", entry.URL)
 		if entry.Provenance.when.IsZero() {
 			entry.Provenance = newProvenance(req)
 		}

--- a/templates/info.tmpl.html
+++ b/templates/info.tmpl.html
@@ -37,6 +37,14 @@
                 </div>
                 <div class="row">
                   <div class="col-3">
+                    <b>Score:</b>
+                  </div>
+                  <div class="col">
+                    {{.Score}}
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-3">
                     <b>EntryCreated:</b>
                   </div>
                   <div class="col">


### PR DESCRIPTION
We want Spectura to auto-refresh cached screenshots once in a while. There are two reasons for this:

* Broken screenshots might be caused by ephemeral issues (e.g. network problems, slow web servers, heavy load on Decap), and simply trying again might fix the everything.

* The content of the web site might change, outdating the screenshot. We want the system to be somewhat self-healing, to avoid handling too many out-of-sync issues manually.

To avoid replacing a good image with a bad one, the refreshed image must have higher information density than the earlier version. We define information density by the absense of large areas with monochrome pixels. (See the calculateScore function for details).