### PR TITLE
Add height and width to images on info page

### DIFF
--- a/info.go
+++ b/info.go
@@ -16,9 +16,11 @@ import (
 )
 
 type RenderableInfo struct {
-	CacheEntries []CacheEntry
-	TotalSize    string
-	TotalEntries int
+	CacheEntries  []CacheEntry
+	TotalSize     string
+	TotalEntries  int
+	OGImageHeight int
+	OGImageWidth  int
 }
 
 func formatDate(date time.Time) string {
@@ -68,6 +70,8 @@ func infoHandler(w http.ResponseWriter, req *http.Request) {
 		entries[:entryLimit],
 		xlib.FmtByteSize(size, 2),
 		len(entries),
+		OGImageHeight,
+		OGImageWidth,
 	}
 	err := tmpl.Execute(w, info)
 	if err != nil {

--- a/templates/grid.tmpl.html
+++ b/templates/grid.tmpl.html
@@ -1,3 +1,5 @@
+{{ $imgWidth := .OGImageWidth }}
+{{ $imgHeight := .OGImageHeight }}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -21,7 +23,7 @@
       <div class="row">
         {{range .CacheEntries}}
         <div class="col-3 mb-3">
-          <img class="img-thumbnail" src="{{.SpecturaURL}}" />
+          <img class="img-thumbnail" src="{{.SpecturaURL}}" width="{{$imgWidth}}" height="{{$imgHeight}}" />
         </div>
         {{end}}
       </div>

--- a/templates/info.tmpl.html
+++ b/templates/info.tmpl.html
@@ -1,3 +1,5 @@
+{{ $imgWidth := .OGImageWidth }}
+{{ $imgHeight := .OGImageHeight }}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -77,7 +79,7 @@
                 </div>
               </div>
               <div class="col-12 col-md-6">
-                <img class="img-thumbnail" src="{{ .SpecturaURL }}" />
+                <img class="img-thumbnail" src="{{ .SpecturaURL }}" width="{{$imgWidth}}" height="{{$imgHeight}}" />
               </div>
             </div>
           </div>


### PR DESCRIPTION
Having the height and width available allows browser to compute the layout height based on the images' aspect ratios even if the rendered size is smaller.

This prevents layout shifts that are especially visible when loading many images on one page.