### PR TITLE
Add auto refresh host blackist

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -100,6 +100,10 @@ Event types contain the same data and are:
 | no
 | `6h`
 
+| `AUTO_REFRESH_HOST_BLACKLIST`
+| no
+| no default ( example: `pyjam.as,www.jobindex.dk` )
+
 |`REFRESH_TASK_DELAY`
 | no
 | `5s`

--- a/cache.go
+++ b/cache.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"time"
+	"slices"
 
 	"github.com/jobindex/spectura/xlib"
 )
@@ -188,6 +189,9 @@ func (c *Cache) serve() {
 					fmt.Fprintf(os.Stderr, "Clearing cache entry %s\n", url)
 				} else {
 					size += len(entry.Image)
+				}
+				if slices.Contains(autoRefreshHostBlacklist, entry.URL.Host) {
+					continue
 				}
 				if time.Since(entry.LastRefreshAttempt) > autoRefreshAfter {
 					go c.runRefreshTask(entry)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       "BG_RATE_LIMIT_TIME": "120s"
       "REFRESH_TASK_DELAY": "10s"
       "AUTO_REFRESH_AFTER": "30s"
+      "AUTO_REFRESH_HOST_BLACKLIST": "pyjam.as"
       "SCHEDULE_INTERVAL": "30s"
       "WEBHOOK_URL": "http://webhook-tester:5000/webhook"
       "ADMIN_TOKEN": "test"

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ const (
 
 var (
 	autoRefreshAfter         time.Duration
+	autoRefreshHostBlacklist []string
 	bgRateLimitTime          time.Duration
 	cacheTTL                 time.Duration
 	decapURL                 string
@@ -63,6 +64,9 @@ func main() {
 	if err != nil {
 		log.Fatalf(`AUTO_REFRESH_AFTER must be a valid duration such as "12h": %s\n`, err)
 	}
+
+	autoRefreshHostBlacklistString, _ := getenv("AUTO_REFRESH_HOST_BLACKLIST", "")
+	autoRefreshHostBlacklist = strings.Split(autoRefreshHostBlacklistString, ",")
 
 	refreshTaskDelayString, _ := getenv("REFRESH_TASK_DELAY", "5s")
 	refreshTaskDelay, err = time.ParseDuration(refreshTaskDelayString)


### PR DESCRIPTION
Allows blacklisting of host you don't want to to automatically refresh.

If you already get `bg` requests from some hosts when the content changes, you can add those hosts to the blacklist, and you won't be needlessly refreshing them periodically.